### PR TITLE
add bootstrap classes to app.js fix layout

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,10 +20,16 @@ const App = props => (
   <div>
     <NavBar />
     <Header />
-    <div className="App">
-        <GroupDetails />
-        <Calendar eventsList={eventsList} />
-        <SlackEmailForm />
+    <div className="App container">
+      <div className="row">
+        <div className="col-9">
+          <GroupDetails />
+        </div>
+        <div className="col-3">
+          <Calendar eventsList={eventsList} />
+          <SlackEmailForm />
+        </div>
+      </div>
     </div>
   </div>
 );

--- a/src/shared/SlackEmailForm.js
+++ b/src/shared/SlackEmailForm.js
@@ -55,7 +55,7 @@ class SlackEmailForm extends Component {
                     <div className='form-group'>
                         <label htmlFor='slack-email-input'>Join our Slack channel!</label>
                         <input 
-                            className= 'form-control'
+                            className='form-control'
                             id='slack-email-input'
                             type='email'
                             placeholder='your-email@email.com'


### PR DESCRIPTION
slack component was getting squished. I moved it below the calendar with bootstrap, so it looks a little cleaner.