### PR TITLE
fix: add correct env-key for slack form

### DIFF
--- a/src/App/credentials.js
+++ b/src/App/credentials.js
@@ -1,3 +1,3 @@
 export default Object.freeze({
-    slackToken: process.env.SLACK_TOKEN || 'include credentials'
+    slackToken: process.env.REACT_APP_SLACK_TOKEN || 'include credentials'
 })

--- a/src/App/services/sendSlackInvite.js
+++ b/src/App/services/sendSlackInvite.js
@@ -4,7 +4,6 @@ import credentials from '../credentials'
 export const sendSlackInvite = (email = '') => {
 
     const inviteApi = `https://slack.com/api/users.admin.invite?resend=true&token=${credentials.slackToken}&email=${email}&channels=C2C6PRY0Y`
-    console.log(credentials.slackToken)
     return axios.get(inviteApi)
         .then(res => res.data.ok)
         .catch(e => {


### PR DESCRIPTION
Per the [create-react-app docs](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables), the only supported `process.env` key is `NODE_ENV`.  All others must be prefaced as `REACT_APP_` to be included in the build. 